### PR TITLE
[機能追加] Notionデータベースへのレコード挿入機能と関連ユーティリティの実装

### DIFF
--- a/notion_api/services/v1/databases.py
+++ b/notion_api/services/v1/databases.py
@@ -64,3 +64,25 @@ class DataBaseService(BaseService):
                 f"v1/databases/{database_id}/query", filter_params
             )["body"]["results"]
         ]
+
+    def insert_record(self, database_id: str, properties: dict):
+        """
+        データベースに新しいレコードを挿入します。
+
+        :param database_id: 挿入先のデータベースID
+        :param properties: 挿入するレコードのプロパティ
+        :return: 作成されたレコードの情報
+        """
+        if not database_id:
+            raise ValueError("Database ID is required")
+        if not properties:
+            raise ValueError("Properties are required")
+
+        data = {"parent": {"database_id": database_id}, "properties": properties}
+
+        response = self.client.post("v1/pages", data)
+
+        if response["code"] == 200:
+            return response["body"]  # Return the body directly
+        else:
+            raise APIClientNotFountError(f"Failed to insert record: {response}")

--- a/notion_api/services/v1/databases.py
+++ b/notion_api/services/v1/databases.py
@@ -65,24 +65,26 @@ class DataBaseService(BaseService):
             )["body"]["results"]
         ]
 
-    def insert_record(self, database_id: str, properties: dict):
+    def insert_record(self, database_id: str, record_data: dict):
         """
         データベースに新しいレコードを挿入します。
 
         :param database_id: 挿入先のデータベースID
-        :param properties: 挿入するレコードのプロパティ
+        :param record_data: 挿入するレコードのデータ
         :return: 作成されたレコードの情報
         """
         if not database_id:
             raise ValueError("Database ID is required")
-        if not properties:
-            raise ValueError("Properties are required")
+        if not record_data:
+            raise ValueError("Record data is required")
 
-        data = {"parent": {"database_id": database_id}, "properties": properties}
+        # Ensure the correct structure of the record_data
+        if "parent" not in record_data or "properties" not in record_data:
+            raise ValueError("Invalid record data structure")
 
-        response = self.client.post("v1/pages", data)
+        response = self.client.post("v1/pages", record_data)
 
         if response["code"] == 200:
-            return response["body"]  # Return the body directly
+            return response["body"]
         else:
             raise APIClientNotFountError(f"Failed to insert record: {response}")

--- a/notion_api/utils/database_record_ops.py
+++ b/notion_api/utils/database_record_ops.py
@@ -1,0 +1,100 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any, List, Union
+
+
+class AbstractProperty(ABC):
+    @abstractmethod
+    def to_dict(self) -> Dict[str, Any]:
+        pass
+
+
+class NumberProperty(AbstractProperty):
+    def __init__(self, value: float):
+        self.value = value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"number": self.value}
+
+
+class TextProperty(AbstractProperty):
+    def __init__(self, content: str):
+        self.content = content
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"title": [{"text": {"content": self.content}}]}
+
+
+class SelectProperty(AbstractProperty):
+    def __init__(self, name: str):
+        self.name = name
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"select": {"name": self.name}}
+
+
+class MultiSelectProperty(AbstractProperty):
+    def __init__(self, names: List[str]):
+        self.names = names
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"multi_select": [{"name": name} for name in self.names]}
+
+
+class DateProperty(AbstractProperty):
+    def __init__(self, start: str, end: str = None):
+        self.start = start
+        self.end = end
+
+    def to_dict(self) -> Dict[str, Any]:
+        date_dict = {"start": self.start}
+        if self.end:
+            date_dict["end"] = self.end
+        return {"date": date_dict}
+
+
+class CheckboxProperty(AbstractProperty):
+    def __init__(self, checked: bool):
+        self.checked = checked
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"checkbox": self.checked}
+
+
+class DatabaseProperties:
+    def __init__(self):
+        self.properties: Dict[str, AbstractProperty] = {}
+
+    def add_property(self, name: str, property: AbstractProperty):
+        self.properties[name] = property
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {name: prop.to_dict() for name, prop in self.properties.items()}
+
+
+class DatabaseRecord:
+    def __init__(self, database_id: str):
+        self.database_id = database_id
+        self.properties = DatabaseProperties()
+
+    def add_property(self, name: str, value: Union[float, str, List[str], bool]):
+        if isinstance(value, (float, int)):
+            prop = NumberProperty(float(value))
+        elif isinstance(value, str):
+            if name.lower() == "name" or name.lower() == "title":
+                prop = TextProperty(value)
+            else:
+                prop = SelectProperty(value)
+        elif isinstance(value, list):
+            prop = MultiSelectProperty(value)
+        elif isinstance(value, bool):
+            prop = CheckboxProperty(value)
+        else:
+            raise ValueError(f"Unsupported property type for {name}: {type(value)}")
+
+        self.properties.add_property(name, prop)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "parent": {"database_id": self.database_id},
+            "properties": self.properties.to_dict(),
+        }

--- a/tests/services/v1/test_databases_services.py
+++ b/tests/services/v1/test_databases_services.py
@@ -11,6 +11,9 @@ from notion_api.utils.databases_filter_builders import (
 )
 from notion_api.services.v1.databases import DataBaseService
 from notion_api.utils.exceptions import APIClientNotFountError
+from notion_api.utils.database_record_ops import DatabaseRecord
+
+database_id = "6ef167bccb674124810c99f06ea1da8f"
 
 
 def test_get_databases_detail():
@@ -41,7 +44,6 @@ def test_get_databases_detail():
 
 def test_get_all_records():
     d = DataBaseService()
-    database_id = "6ef167bccb674124810c99f06ea1da8f"
 
     for i in d.get_database_records(database_id):
 
@@ -51,7 +53,7 @@ def test_get_all_records():
 
 def test_filter_records():
     d = DataBaseService()
-    database_id = "6ef167bccb674124810c99f06ea1da8f"
+
     stock_price_threshold = 5000
 
     # NumberFilterBuilder を使用してフィルターを作成
@@ -153,23 +155,20 @@ def test_filter_records_or_condition():
 
 def test_insert_record():
     d = DataBaseService()
-    database_id = "6ef167bccb674124810c99f06ea1da8f"  # Test database ID
 
-    # Test properties - using only properties that exist in the database
-    properties = {
-        "株価(3/1)": {"number": 5000},
-        "ROE": {"number": 15},
-        "決算": {"select": {"name": "年次決算"}},
-    }
+    record = DatabaseRecord(database_id)
+    record.add_property("株価(3/1)", 9999)
+    record.add_property("ROE", 20)
+    record.add_property("決算", "年次決算")
 
     # Insert record
-    new_record = d.insert_record(database_id, properties)
+    new_record = d.insert_record(database_id, record.to_dict())
 
     # Verify the inserted record
     assert isinstance(new_record, dict)
 
     # Check the properties in the returned data
     result = new_record["properties"]
-    assert result["株価(3/1)"]["number"] == 5000
-    assert result["ROE"]["number"] == 15
+    assert result["株価(3/1)"]["number"] == 9999
+    assert result["ROE"]["number"] == 20
     assert result["決算"]["select"]["name"] == "年次決算"

--- a/tests/services/v1/test_databases_services.py
+++ b/tests/services/v1/test_databases_services.py
@@ -9,6 +9,8 @@ from notion_api.utils.databases_filter_builders import (
     NumberFilterBuilder,
     FilterComposer,
 )
+from notion_api.services.v1.databases import DataBaseService
+from notion_api.utils.exceptions import APIClientNotFountError
 
 
 def test_get_databases_detail():
@@ -147,3 +149,27 @@ def test_filter_records_or_condition():
     assert (
         only_high_stock_price or only_high_roe
     ), "OR condition is not working as expected"
+
+
+def test_insert_record():
+    d = DataBaseService()
+    database_id = "6ef167bccb674124810c99f06ea1da8f"  # Test database ID
+
+    # Test properties - using only properties that exist in the database
+    properties = {
+        "株価(3/1)": {"number": 5000},
+        "ROE": {"number": 15},
+        "決算": {"select": {"name": "年次決算"}},
+    }
+
+    # Insert record
+    new_record = d.insert_record(database_id, properties)
+
+    # Verify the inserted record
+    assert isinstance(new_record, dict)
+
+    # Check the properties in the returned data
+    result = new_record["properties"]
+    assert result["株価(3/1)"]["number"] == 5000
+    assert result["ROE"]["number"] == 15
+    assert result["決算"]["select"]["name"] == "年次決算"


### PR DESCRIPTION
## 変更内容
1. `notion_api/services/v1/databases.py`にレコード挿入機能を追加
2. `notion_api/utils/database_record_ops.py`に新しいユーティリティクラスを追加
3. `tests/services/v1/test_databases_services.py`にレコード挿入のテストを追加

## 詳細説明
1. `DataBaseService`クラスに`insert_record`メソッドを追加し、Notionデータベースへのレコード挿入機能を実装しました。
2. 新しいユーティリティモジュール`database_record_ops.py`を作成し、データベースレコードの操作をサポートする抽象クラスと具体的な実装クラスを追加しました。これにより、さまざまな型のプロパティ（数値、テキスト、選択肢など）を柔軟に扱えるようになりました。
3. `test_databases_services.py`にレコード挿入のテストケースを追加し、新機能の動作を確認しています。

## 影響範囲
- データベース操作に関連するコードに影響があります。
- 既存の機能への影響はありませんが、新しい機能を利用する際は、新しいユーティリティクラスの使用方法に注意が必要です。

## テスト結果
追加されたテストケースが正常に通過することを確認しています。既存のテストにも影響がないことを確認済みです。

## レビューポイント
- `insert_record`メソッドのエラーハンドリングが適切か
- 新しいユーティリティクラスの設計が将来の拡張性を考慮しているか
- テストケースが十分な範囲をカバーしているか
